### PR TITLE
Feature/api 23 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ android:
   components:
     - extra-android-support
     - extra-android-m2repository
-    - build-tools-23.0.1
+    - build-tools-23.0.2
     - android-23
 
 script: touch local.properties && ./gradlew test

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ android:
     - '.+'
 
   components:
+    - tools
     - extra-android-support
     - extra-android-m2repository
     - build-tools-23.0.2

--- a/Qlassified-Android.iml
+++ b/Qlassified-Android.iml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module external.linked.project.id="Qlassified-Android" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$" external.system.id="GRADLE" external.system.module.group="" external.system.module.version="unspecified" type="JAVA_MODULE" version="4">
+  <component name="FacetManager">
+    <facet type="java-gradle" name="Java-Gradle">
+      <configuration>
+        <option name="BUILD_FOLDER_PATH" value="$MODULE_DIR$/build" />
+        <option name="BUILDABLE" value="false" />
+      </configuration>
+    </facet>
+  </component>
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.gradle" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/Qlassified.iml
+++ b/Qlassified.iml
@@ -7,99 +7,13 @@
         <option name="BUILDABLE" value="false" />
       </configuration>
     </facet>
-    <facet type="android-gradle" name="Android-Gradle">
-      <configuration>
-        <option name="GRADLE_PROJECT_PATH" value=":qlassified" />
-      </configuration>
-    </facet>
-    <facet type="android" name="Android">
-      <configuration>
-        <option name="SELECTED_BUILD_VARIANT" value="debug" />
-        <option name="SELECTED_TEST_ARTIFACT" value="_android_test_" />
-        <option name="ASSEMBLE_TASK_NAME" value="assembleDebug" />
-        <option name="COMPILE_JAVA_TASK_NAME" value="compileDebugSources" />
-        <option name="ASSEMBLE_TEST_TASK_NAME" value="assembleDebugAndroidTest" />
-        <option name="COMPILE_JAVA_TEST_TASK_NAME" value="compileDebugAndroidTestSources" />
-        <afterSyncTasks>
-          <task>generateDebugAndroidTestSources</task>
-          <task>generateDebugSources</task>
-        </afterSyncTasks>
-        <option name="ALLOW_USER_CONFIGURATION" value="false" />
-        <option name="MANIFEST_FILE_RELATIVE_PATH" value="/src/main/AndroidManifest.xml" />
-        <option name="RES_FOLDER_RELATIVE_PATH" value="/src/main/res" />
-        <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/qlassified/src/main/res" />
-        <option name="ASSETS_FOLDER_RELATIVE_PATH" value="/src/main/assets" />
-        <option name="LIBRARY_PROJECT" value="true" />
-      </configuration>
-    </facet>
   </component>
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
-    <output url="file://$MODULE_DIR$/qlassified/build/intermediates/classes/debug" />
-    <output-test url="file://$MODULE_DIR$/qlassified/build/intermediates/classes/androidTest/debug" />
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="true">
     <exclude-output />
-    <content url="file://$MODULE_DIR$/qlassified">
-      <sourceFolder url="file://$MODULE_DIR$/qlassified/build/generated/source/r/debug" isTestSource="false" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/qlassified/build/generated/source/aidl/debug" isTestSource="false" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/qlassified/build/generated/source/buildConfig/debug" isTestSource="false" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/qlassified/build/generated/source/rs/debug" isTestSource="false" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/qlassified/build/generated/res/rs/debug" type="java-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/qlassified/build/generated/res/resValues/debug" type="java-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/qlassified/build/generated/source/r/androidTest/debug" isTestSource="true" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/qlassified/build/generated/source/aidl/androidTest/debug" isTestSource="true" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/qlassified/build/generated/source/buildConfig/androidTest/debug" isTestSource="true" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/qlassified/build/generated/source/rs/androidTest/debug" isTestSource="true" generated="true" />
-      <sourceFolder url="file://$MODULE_DIR$/qlassified/build/generated/res/rs/androidTest/debug" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/qlassified/build/generated/res/resValues/androidTest/debug" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/qlassified/src/debug/res" type="java-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/qlassified/src/debug/resources" type="java-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/qlassified/src/debug/assets" type="java-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/qlassified/src/debug/aidl" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/qlassified/src/debug/java" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/qlassified/src/debug/jni" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/qlassified/src/debug/rs" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/qlassified/src/main/res" type="java-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/qlassified/src/main/resources" type="java-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/qlassified/src/main/assets" type="java-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/qlassified/src/main/aidl" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/qlassified/src/main/java" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/qlassified/src/main/jni" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/qlassified/src/main/rs" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/qlassified/src/androidTest/res" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/qlassified/src/androidTest/resources" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/qlassified/src/androidTest/assets" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/qlassified/src/androidTest/aidl" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/qlassified/src/androidTest/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/qlassified/src/androidTest/jni" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/qlassified/src/androidTest/rs" isTestSource="true" />
-      <excludeFolder url="file://$MODULE_DIR$/qlassified/build/docs" />
-      <excludeFolder url="file://$MODULE_DIR$/qlassified/build/intermediates/assets" />
-      <excludeFolder url="file://$MODULE_DIR$/qlassified/build/intermediates/bundles" />
-      <excludeFolder url="file://$MODULE_DIR$/qlassified/build/intermediates/classes" />
-      <excludeFolder url="file://$MODULE_DIR$/qlassified/build/intermediates/coverage-instrumented-classes" />
-      <excludeFolder url="file://$MODULE_DIR$/qlassified/build/intermediates/dependency-cache" />
-      <excludeFolder url="file://$MODULE_DIR$/qlassified/build/intermediates/dex" />
-      <excludeFolder url="file://$MODULE_DIR$/qlassified/build/intermediates/dex-cache" />
-      <excludeFolder url="file://$MODULE_DIR$/qlassified/build/intermediates/incremental" />
-      <excludeFolder url="file://$MODULE_DIR$/qlassified/build/intermediates/jacoco" />
-      <excludeFolder url="file://$MODULE_DIR$/qlassified/build/intermediates/javaResources" />
-      <excludeFolder url="file://$MODULE_DIR$/qlassified/build/intermediates/libs" />
-      <excludeFolder url="file://$MODULE_DIR$/qlassified/build/intermediates/lint" />
-      <excludeFolder url="file://$MODULE_DIR$/qlassified/build/intermediates/manifests" />
-      <excludeFolder url="file://$MODULE_DIR$/qlassified/build/intermediates/ndk" />
-      <excludeFolder url="file://$MODULE_DIR$/qlassified/build/intermediates/pre-dexed" />
-      <excludeFolder url="file://$MODULE_DIR$/qlassified/build/intermediates/proguard" />
-      <excludeFolder url="file://$MODULE_DIR$/qlassified/build/intermediates/res" />
-      <excludeFolder url="file://$MODULE_DIR$/qlassified/build/intermediates/rs" />
-      <excludeFolder url="file://$MODULE_DIR$/qlassified/build/intermediates/symbols" />
-      <excludeFolder url="file://$MODULE_DIR$/qlassified/build/libs" />
-      <excludeFolder url="file://$MODULE_DIR$/qlassified/build/outputs" />
-      <excludeFolder url="file://$MODULE_DIR$/qlassified/build/poms" />
-      <excludeFolder url="file://$MODULE_DIR$/qlassified/build/reports" />
-      <excludeFolder url="file://$MODULE_DIR$/qlassified/build/test-results" />
-      <excludeFolder url="file://$MODULE_DIR$/qlassified/build/tmp" />
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.gradle" />
     </content>
     <orderEntry type="jdk" jdkName="Android API 23 Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" exported="" name="support-annotations-23.1.0" level="project" />
   </component>
 </module>

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ We all need to store sensitive data now and again. On Android, keeping your data
 Add the gradle dependency to your application.
 
 ```java
-compile 'com.q42:qlassified:0.1.0'
+compile 'com.q42:qlassified:0.1.1'
 ```
 
 The library is available on both jCenter and Maven Central so you can use whichever. Whatever floats your boat!

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.0'
+        classpath 'com.android.tools.build:gradle:2.1.2'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.4'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
     }

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    buildToolsVersion "23.0.2"
 
     defaultConfig {
         applicationId "com.q42.classified"
@@ -22,8 +22,8 @@ android {
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:support-v4:23.1.0'
-    compile 'com.android.support:design:23.1.0'
-    compile 'com.android.support:appcompat-v7:23.1.0'
+    compile 'com.android.support:support-v4:23.4.0'
+    compile 'com.android.support:design:23.4.0'
+    compile 'com.android.support:appcompat-v7:23.4.0'
     compile project(':qlassified')
 }

--- a/example/example.iml
+++ b/example/example.iml
@@ -85,16 +85,13 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/builds" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/bundles" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/classes" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/debug" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dependency-cache" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dex" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/animated-vector-drawable/23.4.0/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/appcompat-v7/23.4.0/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/design/23.4.0/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/recyclerview-v7/23.4.0/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/support-v4/23.4.0/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/support-vector-drawable/23.4.0/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.q42/qlassified/0.1.0/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-classes" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-runtime-classes" />
@@ -103,15 +100,12 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/instant-run-support" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/jniLibs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/manifests" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/mockable-android-23.jar" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/pre-dexed" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/reload-dex" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/res" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/restart-dex" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/shaders" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/tmp" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/transforms" />
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
       <excludeFolder url="file://$MODULE_DIR$/build/tmp" />
@@ -119,15 +113,16 @@
     <orderEntry type="jdk" jdkName="Android API 23 Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" exported="" name="design-23.4.0" level="project" />
+    <orderEntry type="library" exported="" name="core-1.54.0.0" level="project" />
     <orderEntry type="library" exported="" name="appcompat-v7-23.4.0" level="project" />
     <orderEntry type="library" exported="" name="support-annotations-23.4.0" level="project" />
     <orderEntry type="library" exported="" name="animated-vector-drawable-23.4.0" level="project" />
     <orderEntry type="library" exported="" name="support-vector-drawable-23.4.0" level="project" />
     <orderEntry type="library" exported="" name="recyclerview-v7-23.4.0" level="project" />
     <orderEntry type="library" exported="" name="support-v4-23.4.0" level="project" />
+    <orderEntry type="library" exported="" name="prov-1.54.0.0" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="hamcrest-core-1.3" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="junit-4.12" level="project" />
-    <orderEntry type="module" module-name="Qlassified" exported="" />
-    <orderEntry type="library" exported="" name="qlassified-0.1.0" level="project" />
+    <orderEntry type="module" module-name="qlassified" exported="" />
   </component>
 </module>

--- a/example/src/main/AndroidManifest.xml
+++ b/example/src/main/AndroidManifest.xml
@@ -2,8 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.q42.qlassified_example" >
 
-    <uses-permission android:name="android.permission.READ_PHONE_STATE" />
-
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"

--- a/example/src/main/res/layout/activity_main.xml
+++ b/example/src/main/res/layout/activity_main.xml
@@ -30,6 +30,8 @@
 
             <EditText
                 android:hint="@string/key_label"
+                android:singleLine="true"
+                android:lines="1"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:id="@+id/put_alias_classified_edittext"
@@ -44,6 +46,8 @@
 
             <EditText
                 android:hint="@string/value_label"
+                android:singleLine="true"
+                android:lines="1"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:id="@+id/put_value_classified_edittext"
@@ -72,6 +76,8 @@
 
             <EditText
                 android:hint="@string/key_label"
+                android:singleLine="true"
+                android:lines="1"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:id="@+id/get_value_classified_edittext"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Oct 28 22:08:05 CET 2015
+#Sun Jun 12 22:02:07 CEST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip

--- a/qlassified/build.gradle
+++ b/qlassified/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    buildToolsVersion "23.0.2"
 
     defaultConfig {
         minSdkVersion 16
@@ -21,7 +21,10 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     testCompile 'junit:junit:4.12'
-    compile 'com.android.support:support-annotations:23.1.0'
+    compile 'com.android.support:support-annotations:23.4.0'
+
+    compile group: 'com.madgag.spongycastle', name: 'core', version: '1.54.0.0'
+    compile group: 'com.madgag.spongycastle', name: 'prov', version: '1.54.0.0'
 }
 
 ext {

--- a/qlassified/build.gradle
+++ b/qlassified/build.gradle
@@ -8,7 +8,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 23
         versionCode 1
-        versionName "0.1.0"
+        versionName "0.1.1"
     }
     buildTypes {
         release {
@@ -40,7 +40,7 @@ ext {
     siteUrl = 'https://github.com/Q42/Qlassified-Android'
     gitUrl = 'https://github.com/Q42/Qlassified-Android.git'
 
-    libraryVersion = '0.1.0'
+    libraryVersion = '0.1.1'
 
     developerId = 'shapoc'
     developerName = 'Jimmy Aupperlee'

--- a/qlassified/qlassified.iml
+++ b/qlassified/qlassified.iml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module external.linked.project.id=":example" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$/.." external.system.id="GRADLE" external.system.module.group="Qlassified" external.system.module.version="unspecified" type="JAVA_MODULE" version="4">
+<module external.linked.project.id=":qlassified" external.linked.project.path="$MODULE_DIR$" external.root.project.path="$MODULE_DIR$/.." external.system.id="GRADLE" external.system.module.group="com.q42" external.system.module.version="0.1.0" type="JAVA_MODULE" version="4">
   <component name="FacetManager">
     <facet type="android-gradle" name="Android-Gradle">
       <configuration>
-        <option name="GRADLE_PROJECT_PATH" value=":example" />
+        <option name="GRADLE_PROJECT_PATH" value=":qlassified" />
       </configuration>
     </facet>
     <facet type="android" name="Android">
@@ -20,13 +20,13 @@
         <option name="RES_FOLDER_RELATIVE_PATH" value="/src/main/res" />
         <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/src/main/res" />
         <option name="ASSETS_FOLDER_RELATIVE_PATH" value="/src/main/assets" />
+        <option name="LIBRARY_PROJECT" value="true" />
       </configuration>
     </facet>
   </component>
   <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_7" inherit-compiler-output="false">
     <output url="file://$MODULE_DIR$/build/intermediates/classes/debug" />
     <output-test url="file://$MODULE_DIR$/build/intermediates/classes/test/debug" />
-    <exclude-output />
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/r/debug" isTestSource="false" generated="true" />
       <sourceFolder url="file://$MODULE_DIR$/build/generated/source/aidl/debug" isTestSource="false" generated="true" />
@@ -80,54 +80,29 @@
       <sourceFolder url="file://$MODULE_DIR$/src/test/jni" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/shaders" isTestSource="true" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/annotations" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/assets" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/blame" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/builds" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/bundles" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/classes" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/debug" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dependency-cache" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/dex" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/animated-vector-drawable/23.4.0/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/appcompat-v7/23.4.0/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/design/23.4.0/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/recyclerview-v7/23.4.0/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/support-v4/23.4.0/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.android.support/support-vector-drawable/23.4.0/jars" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/exploded-aar/com.q42/qlassified/0.1.0/jars" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-classes" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-runtime-classes" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-safeguard" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/incremental-verifier" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/instant-run-support" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/jniLibs" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/manifests" />
+      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/lint" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/mockable-android-23.jar" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/pre-dexed" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/reload-dex" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/res" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/restart-dex" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/shaders" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
-      <excludeFolder url="file://$MODULE_DIR$/build/intermediates/tmp" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/transforms" />
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
       <excludeFolder url="file://$MODULE_DIR$/build/tmp" />
     </content>
     <orderEntry type="jdk" jdkName="Android API 23 Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" exported="" name="design-23.4.0" level="project" />
-    <orderEntry type="library" exported="" name="appcompat-v7-23.4.0" level="project" />
-    <orderEntry type="library" exported="" name="support-annotations-23.4.0" level="project" />
-    <orderEntry type="library" exported="" name="animated-vector-drawable-23.4.0" level="project" />
-    <orderEntry type="library" exported="" name="support-vector-drawable-23.4.0" level="project" />
-    <orderEntry type="library" exported="" name="recyclerview-v7-23.4.0" level="project" />
-    <orderEntry type="library" exported="" name="support-v4-23.4.0" level="project" />
+    <orderEntry type="library" exported="" name="support-annotations-23.1.0" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="hamcrest-core-1.3" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="junit-4.12" level="project" />
-    <orderEntry type="module" module-name="Qlassified" exported="" />
-    <orderEntry type="library" exported="" name="qlassified-0.1.0" level="project" />
   </component>
 </module>

--- a/qlassified/qlassified.iml
+++ b/qlassified/qlassified.iml
@@ -64,14 +64,6 @@
       <sourceFolder url="file://$MODULE_DIR$/src/main/jni" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/rs" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/main/shaders" isTestSource="false" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/res" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/resources" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/assets" type="java-test-resource" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/aidl" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/java" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/jni" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
-      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/shaders" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/res" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/assets" type="java-test-resource" />
@@ -80,6 +72,14 @@
       <sourceFolder url="file://$MODULE_DIR$/src/test/jni" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/rs" isTestSource="true" />
       <sourceFolder url="file://$MODULE_DIR$/src/test/shaders" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/res" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/resources" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/assets" type="java-test-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/aidl" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/jni" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/rs" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/androidTest/shaders" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/annotations" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/assets" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/blame" />
@@ -101,7 +101,9 @@
     </content>
     <orderEntry type="jdk" jdkName="Android API 23 Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" exported="" name="support-annotations-23.1.0" level="project" />
+    <orderEntry type="library" exported="" name="core-1.54.0.0" level="project" />
+    <orderEntry type="library" exported="" name="support-annotations-23.4.0" level="project" />
+    <orderEntry type="library" exported="" name="prov-1.54.0.0" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="hamcrest-core-1.3" level="project" />
     <orderEntry type="library" exported="" scope="TEST" name="junit-4.12" level="project" />
   </component>

--- a/qlassified/src/main/java/com/q42/qlassified/Provider/QlassifiedCrypto.java
+++ b/qlassified/src/main/java/com/q42/qlassified/Provider/QlassifiedCrypto.java
@@ -2,24 +2,22 @@ package com.q42.qlassified.Provider;
 
 import android.util.Base64;
 import android.util.Log;
-
-import java.io.UnsupportedEncodingException;
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
-import java.security.interfaces.RSAPrivateKey;
-import java.security.interfaces.RSAPublicKey;
+import org.spongycastle.jce.provider.BouncyCastleProvider;
 
 import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
+import java.io.UnsupportedEncodingException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.interfaces.RSAPublicKey;
 
 public class QlassifiedCrypto {
 
     public static final String CHARSET = "UTF8";
-    public static final String ALGORITHM = "RSA/ECB/PKCS1Padding";
-    public static final String ANDROID_MODE = "AndroidOpenSSL";
+    public static final String ALGORITHM = "RSA/NONE/PKCS1Padding";
     public static final int BASE64_MODE = Base64.DEFAULT;
 
     public String encrypt(String input, RSAPublicKey publicKey) {
@@ -30,7 +28,7 @@ public class QlassifiedCrypto {
 
         try {
             byte[] dataBytes = input.getBytes(CHARSET);
-            Cipher cipher = Cipher.getInstance(ALGORITHM, ANDROID_MODE);
+            Cipher cipher = Cipher.getInstance(ALGORITHM, new BouncyCastleProvider());
             cipher.init(Cipher.ENCRYPT_MODE, publicKey);
             return Base64.encodeToString(cipher.doFinal(dataBytes), BASE64_MODE);
         } catch (IllegalBlockSizeException |
@@ -38,14 +36,13 @@ public class QlassifiedCrypto {
                 NoSuchAlgorithmException |
                 NoSuchPaddingException |
                 UnsupportedEncodingException |
-                InvalidKeyException |
-                NoSuchProviderException e) {
+                InvalidKeyException e) {
             Log.e("QlassifiedCrypto", String.format("Could not encrypt this string. Stacktrace: %s", e));
             return null;
         }
     }
 
-    public String decrypt(String input, RSAPrivateKey rsaPrivateKey) {
+    public String decrypt(String input, PrivateKey privateKey) {
 
         if (input == null) {
             return null;
@@ -53,15 +50,14 @@ public class QlassifiedCrypto {
 
         try {
             byte[] dataBytes = Base64.decode(input, BASE64_MODE);
-            Cipher cipher = Cipher.getInstance(ALGORITHM, ANDROID_MODE);
-            cipher.init(Cipher.DECRYPT_MODE, rsaPrivateKey);
-            return new String((cipher.doFinal(dataBytes)));
+            Cipher cipher = Cipher.getInstance(ALGORITHM);
+            cipher.init(Cipher.DECRYPT_MODE, privateKey);
+            return new String(cipher.doFinal(dataBytes));
         } catch (IllegalBlockSizeException |
                 BadPaddingException |
                 NoSuchAlgorithmException |
                 NoSuchPaddingException |
-                InvalidKeyException |
-                NoSuchProviderException e) {
+                InvalidKeyException e) {
             Log.e("QlassifiedCrypto", String.format("Could not decrypt this string. Stacktrace: %s", e));
             return null;
         }

--- a/qlassified/src/main/java/com/q42/qlassified/Provider/QlassifiedKeyStore.java
+++ b/qlassified/src/main/java/com/q42/qlassified/Provider/QlassifiedKeyStore.java
@@ -8,34 +8,17 @@ import android.security.KeyPairGeneratorSpec;
 import android.security.keystore.KeyGenParameterSpec;
 import android.security.keystore.KeyProperties;
 import android.util.Log;
-
-import com.q42.qlassified.Entry.EncryptedEntry;
-import com.q42.qlassified.Entry.QlassifiedBoolean;
-import com.q42.qlassified.Entry.QlassifiedEntry;
-import com.q42.qlassified.Entry.QlassifiedFloat;
-import com.q42.qlassified.Entry.QlassifiedInteger;
-import com.q42.qlassified.Entry.QlassifiedLong;
-import com.q42.qlassified.Entry.QlassifiedString;
-
-import java.io.IOException;
-import java.math.BigInteger;
-import java.security.InvalidAlgorithmParameterException;
-import java.security.InvalidKeyException;
-import java.security.KeyPair;
-import java.security.KeyPairGenerator;
-import java.security.KeyStore;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
-import java.security.UnrecoverableEntryException;
-import java.security.cert.CertificateException;
-import java.security.interfaces.RSAPrivateKey;
-import java.security.interfaces.RSAPublicKey;
-import java.security.spec.ECGenParameterSpec;
-import java.util.Calendar;
-import java.util.GregorianCalendar;
+import com.q42.qlassified.Entry.*;
 
 import javax.security.auth.x500.X500Principal;
+import java.io.IOException;
+import java.math.BigInteger;
+import java.security.*;
+import java.security.cert.CertificateException;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.RSAKeyGenParameterSpec;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
 
 @TargetApi(18)
 public class QlassifiedKeyStore implements QlassifiedSecurity {
@@ -83,16 +66,14 @@ public class QlassifiedKeyStore implements QlassifiedSecurity {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
 
             keyPairGenerator = KeyPairGenerator.getInstance(
-                    KeyProperties.KEY_ALGORITHM_EC, ANDROID_KEYSTORE_INSTANCE);
+                    KeyProperties.KEY_ALGORITHM_RSA, ANDROID_KEYSTORE_INSTANCE);
 
             keyPairGenerator.initialize(
                     new KeyGenParameterSpec.Builder(
                             alias,
-                            KeyProperties.PURPOSE_SIGN)
-                            .setAlgorithmParameterSpec(new ECGenParameterSpec("secp256r1"))
-                            .setDigests(KeyProperties.DIGEST_SHA256,
-                                    KeyProperties.DIGEST_SHA384,
-                                    KeyProperties.DIGEST_SHA512)
+                            KeyProperties.PURPOSE_ENCRYPT | KeyProperties.PURPOSE_DECRYPT)
+                            .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_RSA_PKCS1)
+                            .setAlgorithmParameterSpec(new RSAKeyGenParameterSpec(512, RSAKeyGenParameterSpec.F4))
                             .build());
         /**
          * On versions below Marshmellow but above Jelly Bean, use the next best thing
@@ -209,7 +190,7 @@ public class QlassifiedKeyStore implements QlassifiedSecurity {
         String alias = getUniqueDeviceId(this.context);
         try {
             KeyStore.PrivateKeyEntry privateKeyEntry = (KeyStore.PrivateKeyEntry)keyStoreInstance.getEntry(alias, null);
-            RSAPrivateKey privateKey = (RSAPrivateKey) privateKeyEntry.getPrivateKey();
+            PrivateKey privateKey =  privateKeyEntry.getPrivateKey();
             return crypto.decrypt(input, privateKey);
         } catch (NoSuchAlgorithmException |
                 UnrecoverableEntryException |

--- a/qlassified/src/main/java/com/q42/qlassified/Provider/QlassifiedKeyStore.java
+++ b/qlassified/src/main/java/com/q42/qlassified/Provider/QlassifiedKeyStore.java
@@ -134,12 +134,14 @@ public class QlassifiedKeyStore implements QlassifiedSecurity {
         final String decryptedType = decryptedString.substring(splitPosition + 1);
         final String decryptedValue = decryptedString.substring(0, splitPosition);
 
+        final String key = entry.getKey();
+
         switch (QlassifiedEntry.Type.valueOf(decryptedType)) {
-            case BOOLEAN: return new QlassifiedBoolean(decrypt(entry.getKey()), Boolean.valueOf(decryptedValue));
-            case FLOAT: return new QlassifiedFloat(decrypt(entry.getKey()), Float.valueOf(decryptedValue));
-            case INTEGER: return new QlassifiedInteger(decrypt(entry.getKey()), Integer.valueOf(decryptedValue));
-            case LONG: return new QlassifiedLong(decrypt(entry.getKey()), Long.valueOf(decryptedValue));
-            default: return new QlassifiedString(decrypt(entry.getKey()), decryptedValue);
+            case BOOLEAN: return new QlassifiedBoolean(key, Boolean.valueOf(decryptedValue));
+            case FLOAT: return new QlassifiedFloat(key, Float.valueOf(decryptedValue));
+            case INTEGER: return new QlassifiedInteger(key, Integer.valueOf(decryptedValue));
+            case LONG: return new QlassifiedLong(key, Long.valueOf(decryptedValue));
+            default: return new QlassifiedString(key, decryptedValue);
         }
     }
 

--- a/qlassified/src/main/java/com/q42/qlassified/Provider/QlassifiedKeyStore.java
+++ b/qlassified/src/main/java/com/q42/qlassified/Provider/QlassifiedKeyStore.java
@@ -3,19 +3,19 @@ package com.q42.qlassified.Provider;
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.os.Build;
+import android.provider.Settings;
 import android.security.KeyPairGeneratorSpec;
 import android.security.keystore.KeyGenParameterSpec;
 import android.security.keystore.KeyProperties;
-import android.telephony.TelephonyManager;
 import android.util.Log;
 
+import com.q42.qlassified.Entry.EncryptedEntry;
 import com.q42.qlassified.Entry.QlassifiedBoolean;
 import com.q42.qlassified.Entry.QlassifiedEntry;
 import com.q42.qlassified.Entry.QlassifiedFloat;
 import com.q42.qlassified.Entry.QlassifiedInteger;
 import com.q42.qlassified.Entry.QlassifiedLong;
 import com.q42.qlassified.Entry.QlassifiedString;
-import com.q42.qlassified.Entry.EncryptedEntry;
 
 import java.io.IOException;
 import java.math.BigInteger;
@@ -34,7 +34,6 @@ import java.security.interfaces.RSAPublicKey;
 import java.security.spec.ECGenParameterSpec;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
-import java.util.UUID;
 
 import javax.security.auth.x500.X500Principal;
 
@@ -131,23 +130,8 @@ public class QlassifiedKeyStore implements QlassifiedSecurity {
         Log.d("KeyStore", String.format("Private key: %s", keyPair.getPrivate()));
     }
 
-    /**
-     * Amazing method from the interwebs, found here: http://stackoverflow.com/a/2853253
-     * This method ensures a unique identifier for each Android device
-     * @param context {Context} The application context
-     * @return A string unique to the specific device
-     */
     private String getUniqueDeviceId(Context context) {
-
-        final TelephonyManager tm = (TelephonyManager) context.getSystemService(Context.TELEPHONY_SERVICE);
-
-        final String tmDevice, tmSerial, androidId;
-        tmDevice = "" + tm.getDeviceId();
-        tmSerial = "" + tm.getSimSerialNumber();
-        androidId = "" + android.provider.Settings.Secure.getString(context.getContentResolver(), android.provider.Settings.Secure.ANDROID_ID);
-
-        UUID deviceUuid = new UUID(androidId.hashCode(), ((long)tmDevice.hashCode() << 32) | tmSerial.hashCode());
-        return deviceUuid.toString();
+        return Settings.Secure.getString(context.getContentResolver(), Settings.Secure.ANDROID_ID);
     }
 
     public EncryptedEntry encryptEntry(QlassifiedEntry classifiedEntry) {


### PR DESCRIPTION
Sorry for the delay everyone! Here it is!
- Removed the excessive and intrusive permission entirely as mentioned in #2. Newer versions of Android (and this library doesn't support versions below API 16) have the ANDROID_ID set from first booting the device.
- Cherry-picked the fix from https://github.com/Q42/Qlassified-Android/pull/5 to use BouncyCastleProvider
- Added the fix as mentioned in #1 which removes the IllegalBlockSizeException thrown.
- Updated the versions of Gradle and Android libraries.
